### PR TITLE
feat: add VS Code style portfolio interface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
-  "name": "temp",
+  "name": "codestormhub",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "temp",
+      "name": "codestormhub",
       "version": "0.1.0",
       "dependencies": {
         "next": "15.5.2",
         "react": "19.1.0",
-        "react-dom": "19.1.0"
+        "react-dom": "19.1.0",
+        "react-icons": "^5.5.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -5084,6 +5085,15 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -9,19 +9,20 @@
     "lint": "eslint . --ext .ts,.tsx,.js,.jsx"
   },
   "dependencies": {
+    "next": "15.5.2",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "next": "15.5.2"
+    "react-icons": "^5.5.0"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.5.2",
-    "@eslint/eslintrc": "^3"
+    "tailwindcss": "^4",
+    "typescript": "^5"
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,5 @@
+import VSCodeLayout from "@/components/VSCodeLayout";
+
 export default function Home() {
-  return (
-    <main className="flex min-h-screen flex-col items-center justify-center p-6 text-center">
-      <h1 className="text-4xl font-bold">CodeStorm Hub</h1>
-      <p className="mt-4 max-w-2xl text-lg text-gray-600 dark:text-gray-300">
-        Modern portfolio website built with Next.js and Tailwind CSS.
-      </p>
-    </main>
-  );
+  return <VSCodeLayout />;
 }

--- a/src/components/VSCodeLayout.tsx
+++ b/src/components/VSCodeLayout.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useState } from "react";
+import {
+  VscFiles,
+  VscSearch,
+  VscSourceControl,
+  VscExtensions,
+  VscGear,
+} from "react-icons/vsc";
+
+type FileKey = "about.tsx" | "projects.tsx" | "contact.tsx";
+
+const fileContent: Record<FileKey, JSX.Element> = {
+  "about.tsx": (
+    <div className="space-y-2 font-mono">
+      <p className="text-green-400">{"// Welcome to CodeStorm Hub"}</p>
+      <p>
+        <span className="text-purple-400">const</span> developer ={' '}
+        <span className="text-yellow-300">{`{ name: "CodeStorm", role: "Full Stack Developer" }`}</span>;
+      </p>
+      <p className="text-gray-400">
+        {"// Passionate about building interactive web experiences."}
+      </p>
+    </div>
+  ),
+  "projects.tsx": (
+    <div className="space-y-2 font-mono">
+      <p className="text-gray-400">{"// Selected projects"}</p>
+      <ul className="list-disc pl-6">
+        <li>
+          <a
+            className="text-blue-400 underline"
+            href="https://github.com/codestormhub"
+            target="_blank"
+            rel="noreferrer"
+          >
+            GitHub Repositories
+          </a>
+        </li>
+        <li>Portfolio Website</li>
+        <li>Open-source Contributions</li>
+      </ul>
+    </div>
+  ),
+  "contact.tsx": (
+    <div className="space-y-2 font-mono">
+      <p className="text-gray-400">{"// Get in touch"}</p>
+      <p>
+        Email:{' '}
+        <a
+          className="text-blue-400 underline"
+          href="mailto:codestormhub@example.com"
+        >
+          codestormhub@example.com
+        </a>
+      </p>
+      <p>
+        Twitter:{' '}
+        <a
+          className="text-blue-400 underline"
+          href="https://twitter.com/codestormhub"
+          target="_blank"
+          rel="noreferrer"
+        >
+          @codestormhub
+        </a>
+      </p>
+    </div>
+  ),
+};
+
+export default function VSCodeLayout() {
+  const [active, setActive] = useState<FileKey>("about.tsx");
+
+  return (
+    <div className="flex h-screen text-sm text-gray-300">
+      {/* Activity Bar */}
+      <div className="flex w-12 flex-col items-center space-y-4 bg-[#333333] py-4 text-xl">
+        <VscFiles />
+        <VscSearch />
+        <VscSourceControl />
+        <VscExtensions />
+        <div className="mt-auto">
+          <VscGear />
+        </div>
+      </div>
+
+      {/* Explorer */}
+      <div className="w-60 bg-[#252526]">
+        <div className="px-3 py-2 text-xs font-semibold uppercase tracking-widest text-gray-400">
+          Explorer
+        </div>
+        <ul>
+          {(Object.keys(fileContent) as FileKey[]).map((file) => (
+            <li
+              key={file}
+              onClick={() => setActive(file)}
+              className={`cursor-pointer px-3 py-1 hover:bg-[#2a2d2e] ${
+                active === file ? "bg-[#37373d]" : ""
+              }`}
+            >
+              {file}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {/* Editor */}
+      <div className="flex flex-1 flex-col bg-[#1e1e1e]">
+        {/* Tab bar */}
+        <div className="flex border-b border-[#333]">
+          <div className="bg-[#1e1e1e] px-4 py-2">{active}</div>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-auto p-4">{fileContent[active]}</div>
+
+        {/* Status Bar */}
+        <div className="bg-[#007acc] px-4 py-1 text-xs text-white">
+          CodeStorm Hub
+        </div>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add react-icons dependency
- create VSCodeLayout component mimicking VS Code with activity bar, explorer and editor
- render VSCodeLayout on homepage for interactive portfolio feel

## Testing
- `npm run lint`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68b35cecffa4832ab9145614eece79e5